### PR TITLE
Fix incorrect CONFIG_REGISTRY import path in main.py

### DIFF
--- a/myogestic/main.py
+++ b/myogestic/main.py
@@ -9,7 +9,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from myogestic.gui.myogestic import MyoGestic
-#from utils.config import CONFIG_REGISTRY  # noqa
+from myogestic.utils.config import CONFIG_REGISTRY  # noqa
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)

--- a/myogestic/main.py
+++ b/myogestic/main.py
@@ -9,7 +9,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from myogestic.gui.myogestic import MyoGestic
-from utils.config import CONFIG_REGISTRY  # noqa
+#from utils.config import CONFIG_REGISTRY  # noqa
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)


### PR DESCRIPTION

### 🛠 Fix incorrect import path for `CONFIG_REGISTRY` in `main.py`

#### Description

This PR corrects the import path for the `CONFIG_REGISTRY` constant in `main.py`.

Previously, running the application resulted in the following error:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\...\MyoGestic\myogestic\main.py", line 12, in <module>
    from utils.config import CONFIG_REGISTRY  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'utils'
```

To resolve this, I updated the line:

```python
from utils.config import CONFIG_REGISTRY  # noqa
```

to:

```python
from myogestic.utils.config import CONFIG_REGISTRY  # noqa
```

This ensures the correct module is referenced, allowing the application to run as expected when executed directly.

> **Note:** The original import line was **not removed** entirely because it includes a `# noqa` comment, which might have been added intentionally by the original developers. To preserve their intention, I chose to update the path instead of deleting the line altogether.
