### PR TITLE
fix(recording): two teardown races (acquire-loop KeyError + same-second session collision)

### DIFF
--- a/myogestic/_session_core.py
+++ b/myogestic/_session_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import time
 import zipfile
@@ -14,6 +15,8 @@ import zarr
 
 if TYPE_CHECKING:
     from myogestic.stream import StreamInfo
+
+log = logging.getLogger(__name__)
 
 if find_spec("zarrs") is not None:
     zarr.config.set({"codec_pipeline.path": "zarrs.ZarrsCodecPipeline"})
@@ -114,8 +117,21 @@ class Session:
 
     def append(self, name: str, data: np.ndarray, timestamps: np.ndarray) -> None:
         """Called from acquire loop when recording. data: (n_samples, n_channels)."""
-        self.stores[name].append(data)
-        self.ts_stores[name].append(timestamps)
+        # Defense-in-depth: Stream.detach_session() (under its lock) is what
+        # actually prevents an append from racing pack_to_zip()'s clear(); this
+        # guard keeps a stray/late append from raising KeyError if the stores
+        # were already finalised, rather than crashing the caller's thread.
+        store = self.stores.get(name)
+        ts_store = self.ts_stores.get(name)
+        if store is None or ts_store is None:
+            # Should not happen now that Stream.detach_session() drains
+            # in-flight appends before pack_to_zip() clears the stores; log
+            # it so a future regression that drops samples is observable
+            # rather than silent.
+            log.debug("dropping late append for finalised stream %r", name)
+            return
+        store.append(data)
+        ts_store.append(timestamps)
 
     def add_label(self, class_index: int, timestamp: float | None = None) -> None:
         from mne_lsl.lsl import local_clock

--- a/myogestic/_session_core.py
+++ b/myogestic/_session_core.py
@@ -4,6 +4,7 @@ import json
 import logging
 import shutil
 import time
+import uuid
 import zipfile
 from dataclasses import dataclass
 from importlib.util import find_spec
@@ -89,7 +90,12 @@ class Session:
 
     def __init__(self, base_path: str = "sessions"):
         ts = time.strftime("%Y-%m-%d_%H-%M-%S")
-        self.path = Path(base_path) / ts
+        # Append a short random suffix so two sessions started within the same
+        # wall-clock second (e.g. Stop then immediately Record) never share a
+        # folder. pack_to_zip() runs on a daemon thread and shutil.rmtree()s its
+        # own folder; a shared name would let the old session's pack thread wipe
+        # the new recording's data (and collide on the <name>.session.zip path).
+        self.path = Path(base_path) / f"{ts}_{uuid.uuid4().hex[:8]}"
         self.path.mkdir(parents=True, exist_ok=True)
         self.stores: dict[str, zarr.Array] = {}
         self.ts_stores: dict[str, zarr.Array] = {}

--- a/myogestic/core.py
+++ b/myogestic/core.py
@@ -218,7 +218,7 @@ class App:
             if stream.info is None:
                 continue
             self.ctx.session.init_stream(name, stream.info)
-            stream._session = self.ctx.session
+            stream.attach_session(self.ctx.session)
             n_ready += 1
         if n_ready == 0:
             self.ctx.status_message = "No connected streams to record"
@@ -242,8 +242,12 @@ class App:
             )
             return
         self.ctx.state = AppState.IDLE
+        # Detach every stream *before* finalising/packing the session.
+        # detach_session() waits for any in-flight append on the acquire
+        # thread, so the daemon pack thread below can clear the Zarr stores
+        # without racing the acquire loop (was: KeyError mid-append).
         for stream in self.ctx.streams.values():
-            stream._session = None
+            stream.detach_session()
         if self.ctx.session is not None:
             session = self.ctx.session
             session.save_meta(self.name, class_names=self.ctx.class_names or None)

--- a/myogestic/stream.py
+++ b/myogestic/stream.py
@@ -161,6 +161,15 @@ class Stream:
         self._buffer_seconds = buffer_seconds
         self._running = False
         self._session: Session | None = None
+        # Guards `_session` against the acquire loop. `stop_recording()` tears
+        # the session down (and a daemon thread clears its Zarr stores) while
+        # this stream's acquire thread may still be inside `session.append()`.
+        # Holding this lock around both the append and attach/detach makes the
+        # teardown wait for any in-flight append, so the stores are never
+        # cleared mid-append. Deliberately separate from `_lock` (which guards
+        # the display buffers and is read by the GUI thread) so we never block
+        # rendering on Zarr disk I/O — only the rare Stop path ever waits here.
+        self._session_lock = threading.Lock()
         self.status = "disconnected"
         self.last_error = ""
         self.info: StreamInfo | None = None
@@ -285,6 +294,23 @@ class Stream:
         except Exception:
             pass
 
+    def attach_session(self, session: Session) -> None:
+        """Begin recording this stream into ``session`` (called by
+        :meth:`App.start_recording`). Set under ``_session_lock`` so the
+        acquire loop sees a fully-attached session atomically."""
+        with self._session_lock:
+            self._session = session
+
+    def detach_session(self) -> None:
+        """Stop recording this stream (called by :meth:`App.stop_recording`).
+
+        Holding ``_session_lock`` makes this *wait for* any append currently
+        in flight on the acquire thread and guarantees no further append can
+        start. Once this returns, the caller may safely finalise/clear the
+        session's Zarr stores without racing the acquire loop."""
+        with self._session_lock:
+            self._session = None
+
     def _acquire_step(self) -> float:
         """Run one iteration of the acquire loop body.
 
@@ -332,9 +358,14 @@ class Stream:
             self._samples_since_snap = 0
             self._update_m4_snapshot()
 
-        # Append to zarr session if recording
-        if self._session is not None:
-            self._session.append(self.name, data, ts)
+        # Append to zarr session if recording. Hold `_session_lock` across the
+        # check-and-append so `detach_session()` (called from stop_recording)
+        # cannot null the session and clear its stores in the middle of an
+        # append — that race surfaced as `KeyError: '<stream>'` killing this
+        # acquire thread. The lock is uncontended except during teardown.
+        with self._session_lock:
+            if self._session is not None:
+                self._session.append(self.name, data, ts)
 
         # More data may already be queued at the source - don't sleep.
         return 0.0

--- a/tests/test_recording_race.py
+++ b/tests/test_recording_race.py
@@ -1,0 +1,151 @@
+"""Regression tests for the stop-recording / acquire-loop append race.
+
+Background
+----------
+``App.stop_recording()`` nulls each stream's session and then, on a daemon
+thread, calls ``Session.pack_to_zip()`` which clears the session's Zarr
+``stores`` / ``ts_stores``. The per-stream acquire thread may still be inside
+``Session.append()`` (its ``if self._session is not None`` check already
+passed), so the trailing chunk used to land *after* the stores were cleared →
+``KeyError: '<stream>'`` killed the acquire thread.
+
+The fix makes session attach/detach atomic with the acquire loop via
+``Stream._session_lock``: ``detach_session()`` waits for any in-flight append,
+so once it returns no append can be running and clearing the stores is safe.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+
+import numpy as np
+
+from myogestic._session_core import Session
+from myogestic.stream import Stream, StreamInfo
+
+
+class _FixedSource:
+    """Source protocol stub: hands back one small, well-formed chunk per read."""
+
+    def __init__(self, n_channels: int = 2, fs: float = 1000.0) -> None:
+        self._info = StreamInfo(
+            n_channels=n_channels, fs=fs, dtype=np.dtype("float32")
+        )
+
+    def connect(self) -> StreamInfo:
+        return self._info
+
+    def read(self):
+        n = 4
+        data = np.zeros((n, self._info.n_channels), dtype=np.float32)
+        ts = np.arange(n, dtype=np.float64)
+        return data, ts
+
+    def disconnect(self) -> None:
+        pass
+
+
+def _connect_stream(stream: Stream) -> None:
+    """Drive one acquire step so the stream connects + allocates buffers
+    (the first step connects and returns without reading)."""
+    stream._acquire_step()
+    assert stream._connected
+
+
+def test_detach_session_waits_for_inflight_append():
+    """``detach_session()`` must not return while an append is in flight —
+    that mutual exclusion is what stops ``pack_to_zip()``'s ``clear()`` from
+    racing the acquire loop."""
+    stream = Stream("emg", source=_FixedSource(), window_seconds=0.1, buffer_seconds=2)
+    _connect_stream(stream)
+
+    entered = threading.Event()
+    proceed = threading.Event()
+    order: list[str] = []
+
+    class _GatedSession:
+        """Stands in for Session; its append blocks until released so we can
+        observe whether detach_session() waits."""
+
+        def append(self, name, data, timestamps):  # noqa: ANN001
+            order.append("append_enter")
+            entered.set()
+            assert proceed.wait(2.0), "append was never released"
+            order.append("append_exit")
+
+    stream.attach_session(_GatedSession())  # type: ignore[arg-type]
+
+    # Run one acquire step on a worker thread; it will enter the gated append
+    # and block there, holding _session_lock.
+    step = threading.Thread(target=stream._acquire_step, daemon=True)
+    step.start()
+    assert entered.wait(2.0), "acquire step never reached session.append"
+
+    # While the append is in flight, detach must block on _session_lock.
+    detached = threading.Event()
+
+    def _detach():
+        stream.detach_session()
+        order.append("detach_done")
+        detached.set()
+
+    detach_thread = threading.Thread(target=_detach, daemon=True)
+    detach_thread.start()
+
+    # Give detach a chance to (wrongly) complete; it must still be blocked.
+    assert not detached.wait(0.3), "detach_session() returned mid-append (race!)"
+    assert stream._session is not None  # not yet detached
+
+    # Release the append; now detach can proceed.
+    proceed.set()
+    assert detached.wait(2.0), "detach_session() never completed after append"
+    step.join(timeout=2.0)
+
+    assert stream._session is None
+    # The append finished strictly before detach returned.
+    assert order == ["append_enter", "append_exit", "detach_done"]
+
+
+def test_clear_after_detach_does_not_crash_acquire_loop():
+    """Stress complement to the deterministic test above: a real acquire
+    thread streams into a session under load while we repeatedly tear it down
+    in the App's order (detach → clear). The acquire thread must never die.
+
+    The hard guarantee lives in ``test_detach_session_waits_for_inflight_append``;
+    this exercises the same invariant against the real threaded loop."""
+    errors: list[BaseException] = []
+    prev_hook = threading.excepthook
+    threading.excepthook = lambda args: errors.append(args.exc_value)
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            stream = Stream(
+                "emg", source=_FixedSource(), window_seconds=0.1, buffer_seconds=2
+            )
+            stream.start()
+            time.sleep(0.05)  # let it connect + stream
+            assert stream.info is not None
+
+            for _ in range(30):
+                session = Session(base_path=tmp)
+                session.init_stream("emg", stream.info)
+                stream.attach_session(session)
+                time.sleep(0.003)
+                # Teardown order mirrors App.stop_recording(): detach first
+                # (waits for in-flight append), then clear the stores.
+                stream.detach_session()
+                session.stores.clear()
+                session.ts_stores.clear()
+            stream.stop()
+            # Join the acquire thread so a late crash can't slip past the
+            # assertion below (and so excepthook is restored only after it
+            # has fully stopped).
+            acq = getattr(stream, "_thread", None)
+            if acq is not None:
+                acq.join(timeout=2.0)
+                assert not acq.is_alive(), "acquire thread did not stop"
+    finally:
+        threading.excepthook = prev_hook
+
+    assert not errors, f"acquire thread raised: {errors!r}"

--- a/tests/test_session_pack.py
+++ b/tests/test_session_pack.py
@@ -312,3 +312,44 @@ def test_save_meta_omits_class_names_when_none():
         loaded = open_session_store(session.path)
         assert loaded.class_names == []
         shutil.rmtree(session.path, ignore_errors=True)
+
+
+def test_sessions_in_same_second_get_distinct_folders(monkeypatch):
+    """Two sessions created within the same wall-clock second must not share a
+    folder — otherwise the first session's pack_to_zip() (which rmtree's its
+    own folder on a daemon thread) can wipe the second recording's data."""
+    import myogestic._session_core as sc
+
+    monkeypatch.setattr(sc.time, "strftime", lambda *a, **k: "2026-06-03_14-30-05")
+    with tempfile.TemporaryDirectory() as tmp:
+        s1 = Session(base_path=tmp)
+        s2 = Session(base_path=tmp)
+        assert s1.path != s2.path
+        assert s1.path.exists() and s2.path.exists()
+
+
+def test_pack_does_not_delete_a_concurrent_same_second_session(monkeypatch):
+    """Reproduce the Stop-then-immediately-Record data-loss scenario: with a
+    shared (second-resolution) folder name, s1.pack_to_zip() deleted s2's data.
+    Distinct folders keep s2 intact."""
+    import myogestic._session_core as sc
+
+    monkeypatch.setattr(sc.time, "strftime", lambda *a, **k: "2026-06-03_14-30-05")
+    with tempfile.TemporaryDirectory() as tmp:
+        info = StreamInfo(n_channels=2, fs=64.0, dtype=np.dtype("float32"))
+
+        s1 = Session(base_path=tmp)
+        s1.init_stream("emg", info)
+        s1.append("emg", np.ones((8, 2), np.float32), np.arange(8, dtype=np.float64))
+        s1.save_meta("FirstSession")
+
+        s2 = Session(base_path=tmp)
+        s2.init_stream("emg", info)
+        s2.append("emg", np.full((8, 2), 2.0, np.float32), np.arange(8, dtype=np.float64))
+
+        # s1 finalises (rmtree's s1.path). s2 must be untouched.
+        s1.pack_to_zip()
+
+        assert s2.path.exists()
+        assert np.array(s2.stores["emg"]).shape == (8, 2)
+        assert np.allclose(np.array(s2.stores["emg"]), 2.0)


### PR DESCRIPTION
## Summary

Fixes two race conditions in the recording teardown path that can crash the acquire thread or destroy a recording. Both are reachable from normal UI use and exist in released 2.0.1.

## Bug 1: acquire-loop append races session teardown (KeyError)

Clicking Stop calls `App.stop_recording()`, which nulls each stream's session and then, on a daemon thread, runs `Session.pack_to_zip()` -> `stores.clear()` / `ts_stores.clear()`. The per-stream acquire loop checked `if self._session is not None:` and called `self._session.append(...)` outside any lock. An append already in flight (between the data-store write and the timestamp-store write) could land after the stores were cleared, raising `KeyError: '<stream>'` and killing the acquire thread.

Root cause is a lifecycle race: `_session` was read and used by the acquire loop with no synchronization against teardown mutating it and clearing the stores. Setting `_session = None` did not cover an append already executing.

Fix:
* New `Stream._session_lock`, separate from `_lock` (which guards buffer/window access used by UI-facing reads such as `get_window()` and `last_timestamp()`), so teardown never puts Zarr disk I/O under the display/buffer lock.
* The acquire loop holds `_session_lock` across the check-and-append.
* New `Stream.attach_session()` / `detach_session()` set `_session` under the same lock. `detach_session()` waits for any in-flight append before returning.
* `App.start_recording()` / `stop_recording()` use these methods. Stop detaches all streams before the pack thread clears the stores, so the clear can no longer race the acquire loop.
* `Session.append()` gains a defense-in-depth guard that returns early (and logs at debug level) if the store was already finalized, instead of raising.

## Bug 2: sessions started in the same second share a folder

`Session.__init__` named the recording folder with a second-resolution timestamp and created it with `mkdir(exist_ok=True)`. Clicking Stop and immediately Record within the same wall-clock second produced two sessions pointing at one folder. The first session's `pack_to_zip()` runs on a daemon thread and `shutil.rmtree()`s that folder (and writes `<name>.session.zip`), so it could delete the second recording's data mid-capture and collide on the zip path.

Fix: append a short `uuid4` suffix to the folder name so rapid same-second sessions no longer deterministically share one folder. The folder name is only used to derive the zip name and for display and logging; nothing parses it as a timestamp, so the format change is safe.

## Tests

New `tests/test_recording_race.py`:
* `test_detach_session_waits_for_inflight_append`: deterministic proof that `detach_session()` blocks until an in-flight append completes.
* `test_clear_after_detach_does_not_crash_acquire_loop`: a real acquire thread under load is torn down repeatedly in the App's order and never dies.

New cases in `tests/test_session_pack.py`:
* `test_sessions_in_same_second_get_distinct_folders`
* `test_pack_does_not_delete_a_concurrent_same_second_session` (reproduces the data-loss scenario; fails on the old shared-path behavior).

All new tests pass and were checked to fail on the pre-fix behavior. The unrelated pre-existing failures in `test_interfaces.py` (missing VHI Godot binary) and `test_public_api.py` are not touched by this change.

## Notes

* All three acquire drive paths (threaded `_acquire_loop`, async `_acquire_loop_async`, browser `register(...)`) go through the guarded `_acquire_step`, and the only `_session.append` call site is inside that guarded block, so every path is covered.
* `detach_session()` briefly waits on at most one in-flight chunk write at Stop. A `Condition`-based counter could remove that wait if it ever becomes noticeable, but it is not a correctness concern.
